### PR TITLE
Pass explicit key file to SSH auth, improve error on auth failure

### DIFF
--- a/fileops_server.py
+++ b/fileops_server.py
@@ -123,10 +123,11 @@ def deploy_clients(clients, access):
 
     """
     rsa_pub_key = ensure_ssh_key(SSH_PUB_KEY_PATH)
+    priv_key_path = SSH_PUB_KEY_PATH.rsplit('.pub', 1)[0]
     for client in clients:
         logger.info(f"Setting SSH connection to {client}")
         ssh_utils.set_key_policy(rsa_pub_key, client, access['user'],
-                                 access['password'])
+                                 access['password'], key_filename=priv_key_path)
         logger.info(f"Deploying to {client}")
         ShellUtils.run_shell_remote_command_no_exception(client, 'mkdir -p {}'.format(config.DYNAMO_PATH))
         ShellUtils.run_shell_command('rsync',
@@ -227,8 +228,10 @@ def main():
     logger.info(f"Operation journal: {test_config['_journal'].path}")
     logger.info("Setting passwordless SSH connection")
     rsa_pub_key = ensure_ssh_key(SSH_PUB_KEY_PATH)
+    priv_key_path = SSH_PUB_KEY_PATH.rsplit('.pub', 1)[0]
     ssh_utils.set_key_policy(rsa_pub_key, args.cluster, test_config['access']['server']['user'],
-                             test_config['access']['server']['password'])
+                             test_config['access']['server']['password'],
+                             key_filename=priv_key_path)
 
     if args.locking == 'application':
         logger.info("Flushing locking DB")

--- a/utils/ssh_utils.py
+++ b/utils/ssh_utils.py
@@ -61,21 +61,21 @@ def is_hostname(hostname):
         return False
 
 
-def _can_pubkey_connect(host, username, port=22, timeout=10):
+def _can_pubkey_connect(host, username, key_filename=None, port=22, timeout=10):
     """Return True if we can already connect to host using public key auth."""
     try:
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         ssh.connect(host, username=username, port=port, timeout=timeout,
-                    look_for_keys=True, allow_agent=True)
+                    key_filename=key_filename, look_for_keys=True, allow_agent=True)
         ssh.close()
         return True
     except (paramiko.AuthenticationException, paramiko.SSHException, socket_error):
         return False
 
 
-def set_key_policy(key, host, username, password, port=22):
-    if _can_pubkey_connect(host, username, port):
+def set_key_policy(key, host, username, password, port=22, key_filename=None):
+    if _can_pubkey_connect(host, username, key_filename=key_filename, port=port):
         return True
 
     try:
@@ -91,7 +91,11 @@ def set_key_policy(key, host, username, password, port=22):
         if sock_err.errno == errno.ECONNREFUSED:
             raise sock_err
     except paramiko.BadAuthenticationType as authtype_err:
-        raise authtype_err
+        raise RuntimeError(
+            f"Cannot connect to {host} as '{username}': password auth is disabled "
+            f"and pubkey auth failed. Check that server/config.json has the correct "
+            f"username and that the SSH key is in ~{username}/.ssh/authorized_keys"
+        ) from authtype_err
     except Exception as general_paramiko_ex:
         raise general_paramiko_ex
 


### PR DESCRIPTION
_can_pubkey_connect and set_key_policy now accept a key_filename parameter so the correct private key is used regardless of the remote username. Replace the raw BadAuthenticationType with a RuntimeError that tells the user to check config.json credentials.

Made-with: Cursor