### PR TITLE
Skip Redis in client when not using application locking

### DIFF
--- a/client/dynamo.py
+++ b/client/dynamo.py
@@ -60,10 +60,13 @@ class Dynamo(object):
             self._socket.identity = "{0}:0x{1:x}".format(socket.gethostname(), os.getpid()).encode()
             self.logger.info("Setting up connection to Controller Server...")
             self._socket.connect("tcp://{0}:{1}".format(self._controller_ip, CTRL_MSG_PORT))
-            # Initialising connection to Redis (our byte-range locking DB)
-            self.logger.info("Setting up Redis connection...")
-            self.locking_db = redis.StrictRedis(**redis_config)
-            self.flock = FLock(self.locking_db, kwargs.get('locking_type'))
+            locking_type = kwargs.get('locking_type', 'native')
+            if locking_type == 'application':
+                self.logger.info("Setting up Redis connection for application locking...")
+                self.locking_db = redis.StrictRedis(**redis_config)
+            else:
+                self.locking_db = None
+            self.flock = FLock(self.locking_db, locking_type)
             self.logger.info(f"Dynamo {self._socket.identity} init done")
         except Exception as e:
             self.logger.error(f"Connection error: {e}")

--- a/client/locking.py
+++ b/client/locking.py
@@ -26,6 +26,7 @@ class LockException(OSError):
 class FLock(object):
     def __init__(self, locking_db, locking_type="native"):
         self.locking_db = locking_db
+        self.locking_type = locking_type
         self.pid = os.getpid()
         self.host = socket.gethostname()
 
@@ -79,6 +80,8 @@ class FLock(object):
         :param length: int
         :return:
         """
+        if self.locking_type != "application":
+            return
         lock_id = xxhash.xxh64("".join(map(str, [fid, self.host, self.pid, offset, length]))).intdigest()
         self.locking_db.hdel(os.fstat(fid).st_ino, lock_id)
 


### PR DESCRIPTION
Dynamo client unconditionally connected to Redis even in native/off locking modes, causing ConnectionRefused errors. Now only creates the Redis connection when locking_type is 'application'. FLock.release() also short-circuits for non-application modes instead of always calling locking_db.hdel().

Made-with: Cursor